### PR TITLE
Update init.pp

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name    'wcooley/splunk_conf'
-version '0.1.0'
+version '0.1.1'
 source 'UNKNOWN'
 author 'wcooley'
 license 'Apache License, Version 2.0'

--- a/lib/augeas/lenses/splunk.aug
+++ b/lib/augeas/lenses/splunk.aug
@@ -1,41 +1,30 @@
 (*
-Module: Splunk
-  Parses /opt/splunk/etc/*
-
-Author: Tim Brigham
-
-About: Reference
-  http://docs.splunk.com/Documentation/Splunk/5.0.2/Admin/AboutConfigurationFiles
-
-About: License
-   This file is licenced under the LGPL v2+
-
-About: Lens Usage
-   Works like IniFile lens, with anonymous section for entries without enclosing section.
-
-About: Configuration files
-   This lens applies to conf files under /opt/splunk/etc See <filter>.
-
-About: Examples
-   The <Test_Splunk> file contains various examples and tests.
+* Splunk module for Agueas
+* Author: Tim Brigham
+* Heavily based on inifile.aug by Raphael Pinson
+* and mysql.aug by Tim Stoop.
+* This file is licensed under the LGPLv2+, like the rest of Augeas.
 *)
 
 module Splunk =
-  autoload xfm
+autoload xfm
 
-  let comment   = IniFile.comment IniFile.comment_re IniFile.comment_default
-  let sep       = IniFile.sep IniFile.sep_re IniFile.sep_default
-  let empty     = IniFile.empty
+let comment  = IniFile.comment IniFile.comment_re IniFile.comment_default
+let sep      = IniFile.sep IniFile.sep_re IniFile.sep_default
+let empty    = IniFile.empty
 
-  let setting   = IniFile.entry_re
-  let title     =  IniFile.indented_title_label "target" IniFile.record_label_re
-  let entry     = [ key IniFile.entry_re . sep . IniFile.sto_to_eol? . IniFile.eol ] | comment
+let setting   = IniFile.entry_re
+let title   =  IniFile.indented_title_label "target" IniFile.record_label_re
+let entry    = [ key IniFile.entry_re . sep . IniFile.sto_to_comment . (comment|IniFile.eol) ] |
+               [ key IniFile.entry_re . store // . (comment|IniFile.eol) ] |
+               [ key /\![A-Za-z][A-Za-z0-9\._-]+/ . del / / " " . store /\/[A-Za-z0-9\.\/_-]+/ . (comment|IniFile.eol) ] |
+               comment
 
+let record    = IniFile.record title entry
+let record_anon = [ label ".anon" . ( entry | empty )+ ]
 
-  let record    = IniFile.record title entry
-  let anon      = [ label ".anon" . (entry|empty)+ ]
-  let lns       = anon . (record)* | (record)*
+let lns       = record_anon | record*
 
-  let filter    = incl "/opt/splunk/etc/system/local/*.conf"
-                . incl "/opt/splunk/etc/apps/*/local/*.conf"
-  let xfm       = transform lns filter
+let filter    = incl "/opt/splunk/etc/system/local/*.conf"
+              . incl "/opt/splunk/etc/apps/*/local/*.conf"
+let xfm       = transform lns filter

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,22 +23,33 @@
 #
 # === Examples
 #
-#   splunk_conf { 'monitor:///foo/bar/baz.log':
+#   splunk_conf { 'baz.log':
 #     config_file  => '/opt/splunkforwarder/etc/system/local/inputs.conf',
+#     stanza       => 'monitor:///foo/bar/baz/log',
 #     set          => {
 #       sourcetype => 'foo',
 #     },
 #     rm => [ 'disabled' ],
 #   }
 #
-#   splunk_conf { 'monitor:///foo/bar/baz.log':
+#   splunk_conf { 'baz.log':
 #     config_file => '/opt/splunkforwarder/etc/system/local/inputs.conf',
+#     stanza       => 'monitor:///foo/bar/baz/log',
 #     ensure      => 'absent',
+#   }
+#
+#   splunk_conf { 'server_splunkd_settings':
+#     config_file    => '/opt/splunk/etc/system/local/web.conf',
+#     stanza         => 'settings',
+#     set            => {
+#       mgmtHostPort => '127.0.0.1:18089',
+#     }
+#     ensure      => 'present',
 #   }
 #
 # === Authors
 #
-# Wil Cooley <wcooley@nakedape.cc>
+# Wil Cooley <wcooley@nakedape.cc> and modified by Alex Scoble <itblogger@gmail.com>
 #
 # === Copyright
 #
@@ -58,6 +69,7 @@
 #
 define splunk_conf (
     $config_file,
+    $stanza,
     $set = {},
     $rm = [],
     $ensure = 'present'
@@ -66,13 +78,13 @@ define splunk_conf (
   case $ensure {
     'present': {
       $changes = flatten([
-        "defnode target target[. = '${title}'] ${title}",
+        "defnode target target[. = '${stanza}'] ${stanza}",
         prefix(join_keys_to_values($set, ' '), 'set $target/'),
         prefix($rm, 'rm $target/'),
       ])
     }
     'absent': {
-      $changes = "rm target[. = '${title}']"
+      $changes = "rm target[. = '${stanza}']"
     }
     default: {
       fail("status=unrecognized_value name=ensure value=\"${ensure}\"")


### PR DESCRIPTION
Added $stanza variable and changed module to use that to build the changes. This solves the problem of not being able to modify the same stanza in two different conf files. This is an issue when you have Splunk and Universal Forwarder installed on the same box and want to edit the web.conf for both, for instance.
